### PR TITLE
.gitignore: remove exception for terraform.tfvars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ id_rsa*
 *openrc.sh
 .terraform
 terraform*
-!terraform.tfvars
 .terraform.tfstate.lock.info
 .terraform.lock.hcl
 ssh_config


### PR DESCRIPTION
Is there any reason why the terraform.vars file should not be ignored? Why should this be tracked by git?